### PR TITLE
@snippet_files => nil

### DIFF
--- a/app/views/admin/snippet_files/index.html.haml
+++ b/app/views/admin/snippet_files/index.html.haml
@@ -9,7 +9,7 @@
           - thead.title_header do
             %th.name= t('snippet')
     %tbody
-      - if @snippet_files.any?
+      - if not @snippet_files.blank?
         - @snippet_files.each do |snippet|
           %tr[snippet]
             - render_region :tbody, :locals => {:snippet => snippet} do |tbody|


### PR DESCRIPTION
... when snippet files are empty. Radiant 1.1.3

```
You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.any?
Extracted source (around line #12):

9:           - thead.title_header do
10:             %th.name= t('snippet')
11:     %tbody
12:       - if @snippet_files.any?
13:         - @snippet_files.each do |snippet|
14:           %tr[snippet]
15:             - render_region :tbody, :locals => {:snippet => snippet} do |tbody|
```
